### PR TITLE
feat: add AGENTS.md for cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Ticketscoup
+
+A Next.js 15 full-stack ticketing system using Hono (API), Prisma (ORM), PostgreSQL, NextAuth v5, Firebase Cloud Messaging, and BunnyCDN.
+
+## Cursor Cloud specific instructions
+
+### Services
+
+| Service | How to start | Port |
+|---------|-------------|------|
+| Next.js dev server | `npm run dev` | 3000 |
+| PostgreSQL | `sudo service postgresql start` | 5432 |
+
+### Key commands
+
+- **Dev server:** `npm run dev`
+- **Lint:** `npm run lint`
+- **Format:** `npm run pretty`
+- **Prisma migrate:** `npx prisma migrate dev --name <name>`
+- **Prisma generate:** `npx prisma generate`
+
+### Gotchas
+
+- **Peer dependency conflict:** Use `npm ci --legacy-peer-deps` (or `npm install --legacy-peer-deps`) because `tailwind-scrollbar@4` expects `tailwindcss@4.x` while the project uses `tailwindcss@3.4`.
+- **Env validation (`src/_instrumentation.ts`):** The file has an underscore prefix and is NOT auto-loaded by Next.js, so `npm run dev` starts without strict env validation. This is intentional for the current state of the codebase.
+- **PostgreSQL must be running** before starting the dev server or running migrations. Start with `sudo service postgresql start`.
+- **Database credentials:** The dev database is `ticketscoup` with user/password `ticketscoup/ticketscoup` at `localhost:5432`.
+- **API routes** are mounted at `/api/*` via Hono (see `src/app/api/[[...route]]/route.ts`). API reference docs are at `/api/reference`.
+- **Auth:** GitHub OAuth and email magic-link auth require real credentials to function. For local dev without auth, use the Hono API endpoints directly (team/ticket endpoints have no auth middleware).
+- **Pre-existing lint errors:** The codebase has pre-existing ESLint warnings/errors (unused vars, `any` types). These are not regressions.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment documentation for Cursor Cloud agents.

### What's included

- Service overview table (Next.js dev server, PostgreSQL)
- Key commands reference (dev, lint, format, migrations)
- Non-obvious gotchas discovered during setup:
  - `npm ci --legacy-peer-deps` required due to tailwind-scrollbar/tailwindcss version conflict
  - `_instrumentation.ts` underscore prefix means env validation doesn't auto-run
  - Database setup prerequisites
  - API route structure and auth-free endpoints for local testing

### Verification

The development environment was fully verified:
- PostgreSQL 16 installed and running
- Prisma migrations applied successfully
- Next.js dev server starts and responds on port 3000
- API endpoints working (tested CRUD on ticket types)
- ESLint runs (pre-existing errors only)
- UI renders correctly (homepage, signin, API reference docs)

[API reference docs page](https://cursor.com/agents/bc-6eca3a41-151b-47f6-9fb4-acc050c770e9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_reference.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6eca3a41-151b-47f6-9fb4-acc050c770e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6eca3a41-151b-47f6-9fb4-acc050c770e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

